### PR TITLE
Adhere DEX order to limit order behaviour with multiple counter orders support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Enjoy:
 
 ### DEX with partial filling contracts
 
-[Run in Scastie](https://scastie.scala-lang.org/YCzvl8NBQwa7R0pVI5mHnA)
+[Run in Scastie](https://scastie.scala-lang.org/mh3h6SrESnKJwdqZjKnVkw)
 
-[Source code](https://github.com/ergoplatform/ergo-playgrounds/blob/c91117ae0b1434b7a554028592e30a5bba15a14b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/AssetsAtomicExchangePlayground.scala#L1-L1)
+[Source code](https://github.com/ergoplatform/ergo-playgrounds/blob/e42b5f14e9bfc50be27d69db44e40e17a3d7e58f/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala#L3)
 
 ### Assets Atomic Exchange contracts
 

--- a/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
+++ b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
@@ -82,7 +82,7 @@ object DEXPlayground {
             returnBox.value >= fullSpread
         }
 
-        val coinsSecured = partialMatching ||totalMatching
+        val coinsSecured = partialMatching || totalMatching
 
         val tokenIdIsCorrect = returnBox.tokens.getOrElse(0, (Coll[Byte](), 0L))._1 == tokenId
         

--- a/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
+++ b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
@@ -16,10 +16,6 @@ object DEXPlayground {
     val buyerContractEnv: ScriptEnv =
       Map("buyerPk" -> buyerPk, "tokenId" -> token.tokenId)
 
-    // TODO: put contract type (sell/buy) in register and check in INPUTS filter?
-    // TODO: show contract cost
-    // TODO: move price check (from fullSpread) to boxesAreSortedByTokenPrice?
-    // TODO: if both orders were in the same block who gets the spread?
     val buyerScript = s"""buyerPk || {
 
       val tokenPrice = $tokenPrice

--- a/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
+++ b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
@@ -50,8 +50,13 @@ object DEXPlayground {
         val expectedDexFee = dexFeePerToken * returnTokenAmount
         
         val foundNewOrderBoxes = OUTPUTS.filter { (b: Box) => 
-          val contractParametersAreCorrect = b.R4[Coll[Byte]].get == tokenId && b.R5[Long].get == tokenPrice
-          b.R7[Coll[Byte]].isDefined && b.R7[Coll[Byte]].get == SELF.id && b.propositionBytes == SELF.propositionBytes
+          val tokenIdParameterIsCorrect = b.R4[Coll[Byte]].isDefined && b.R4[Coll[Byte]].get == tokenId 
+          val tokenPriceParameterIsCorrect = b.R5[Long].isDefined && b.R5[Long].get == tokenPrice
+          val dexFeePerTokenParameterIsCorrect = b.R6[Long].isDefined && b.R6[Long].get == dexFeePerToken
+          val contractParametersAreCorrect = tokenIdParameterIsCorrect && tokenPriceParameterIsCorrect
+          val referenceMe = b.R7[Coll[Byte]].isDefined && b.R7[Coll[Byte]].get == SELF.id 
+          val guardedByTheSameContract = b.propositionBytes == SELF.propositionBytes
+          contractParametersAreCorrect && referenceMe && guardedByTheSameContract
         }
 
         val fullSpread = {
@@ -329,7 +334,7 @@ object DEXPlayground {
       value     = newBuyOrderBoxValue,
       script    = newBuyOrderContract,
       registers = R4 -> token.tokenId,
-      R5 -> sellerAskTokenPrice,
+      R5 -> buyersBidTokenPrice,
       R6 -> buyerDexFeePerToken,
       R7 -> buyOrderTxSigned.outputs(0).id
     )

--- a/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
+++ b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
@@ -16,9 +16,9 @@ object DEXPlayground {
     val buyerContractEnv: ScriptEnv =
       Map("buyerPk" -> buyerPk, "tokenId" -> token.tokenId)
 
-    // TODO : check that counter orders are sorted by token price
-    // TODO: if both orders were in the same block who gets the spread?
+    // TODO: check that counter orders are sorted by token price
     // TODO: move price check (from fullSpread) to boxesAreSortedByTokenPrice?
+    // TODO: if both orders were in the same block who gets the spread?
     val buyerScript = s"""buyerPk || {
 
       val tokenPrice = $tokenPrice
@@ -59,14 +59,9 @@ object DEXPlayground {
             if (sellOrder.creationInfo._1 >= SELF.creationInfo._1 && sellOrderTokenPrice <= tokenPrice) {
               // spread is ours
               val spreadPerToken = tokenPrice - sellOrderTokenPrice
-              // TODO: rewrite with min(returnTokensLeft, sellOrderTokenAmount)?
-              if (returnTokensLeft < sellOrderTokenAmount) {
-                val sellOrderSpread = spreadPerToken * returnTokensLeft
-                (0L, accumulatedFullSpread + sellOrderSpread)
-              } else {
-                val sellOrderSpread = spreadPerToken * sellOrderTokenAmount
-                (returnTokensLeft - sellOrderTokenAmount, accumulatedFullSpread + sellOrderSpread)
-              }
+              val tokenAmount = min(returnTokensLeft, sellOrderTokenAmount)
+              val sellOrderSpread = spreadPerToken * tokenAmount
+              (returnTokensLeft - tokenAmount, accumulatedFullSpread + sellOrderSpread)
             }
             else {
               // spread is not ours

--- a/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
+++ b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
@@ -161,7 +161,7 @@ object DEXPlayground {
             val buyOrderTokenPrice = buyOrder.R5[Long].get
             val buyOrderDexFeePerToken = buyOrder.R6[Long].get
             val buyOrderTokenAmount = buyOrder.value / (buyOrderTokenPrice + buyOrderDexFeePerToken)
-            if (buyOrder.creationInfo._1 >= SELF.creationInfo._1 && buyOrderTokenPrice <= tokenPrice) {
+            if (buyOrder.creationInfo._1 > SELF.creationInfo._1 && buyOrderTokenPrice <= tokenPrice) {
               // spread is ours
               val spreadPerToken = tokenPrice - buyOrderTokenPrice
               val tokenAmountLeft = min(returnTokensLeft, buyOrderTokenAmount)

--- a/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
+++ b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
@@ -145,9 +145,13 @@ object DEXPlayground {
         val returnBox = returnBoxes(0)
 
         val foundNewOrderBoxes = OUTPUTS.filter { (b: Box) => 
-          val contractParametersAreCorrect = b.R4[Coll[Byte]].get == tokenId && b.R5[Long].get == tokenPrice
-          val contractIsTheSame = b.propositionBytes == SELF.propositionBytes
-          b.R7[Coll[Byte]].isDefined && b.R7[Coll[Byte]].get == SELF.id && contractIsTheSame
+          val tokenIdParameterIsCorrect = b.R4[Coll[Byte]].isDefined && b.R4[Coll[Byte]].get == tokenId 
+          val tokenPriceParameterIsCorrect = b.R5[Long].isDefined && b.R5[Long].get == tokenPrice
+          val dexFeePerTokenParameterIsCorrect = b.R6[Long].isDefined && b.R6[Long].get == dexFeePerToken
+          val contractParametersAreCorrect = tokenIdParameterIsCorrect && tokenPriceParameterIsCorrect
+          val referenceMe = b.R7[Coll[Byte]].isDefined && b.R7[Coll[Byte]].get == SELF.id 
+          val guardedByTheSameContract = b.propositionBytes == SELF.propositionBytes
+          contractParametersAreCorrect && referenceMe && guardedByTheSameContract
         }
 
         val fullSpread = { (tokenAmount: Long) =>

--- a/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
+++ b/playgrounds/src/main/scala/org/ergoplatform/playgrounds/examples/DEXPlayground.scala
@@ -30,6 +30,8 @@ object DEXPlayground {
         }
       }
 
+      // TODO: check that counter orders are sorted by token price
+
       // TODO: only part of it is matched
       // TODO: for multiplse sell orders sort by price
       // val spendingSellOrderTokenInfo = spendingSellOrders.map { (b: Box) => 

--- a/playgrounds/src/test/scala/org/ergoplatform/playgrounds/examples/test/DEXPlaygroundSpec.scala
+++ b/playgrounds/src/test/scala/org/ergoplatform/playgrounds/examples/test/DEXPlaygroundSpec.scala
@@ -1,6 +1,5 @@
 package org.ergoplatform.playgrounds.examples.test
 
-import org.ergoplatform.playgrounds.examples.AssetsAtomicExchangePlayground
 import org.scalatest.PropSpec
 import org.ergoplatform.playgrounds.examples.DEXPlayground
 


### PR DESCRIPTION
Branched from #13 

Challenge 1.
Figure out how "select" proper counter orders without a 'sort' op. Example:
For older buy order (price 5 ergs, total 15 ergs) which is matched with 2 newer sell orders (price 5, 2 tokens), (price 4, 2 tokens) how to start "selecting" tokens from the second sell order and finish with the first order?
Without the solution, we'd have to limit to 1-1 (single counter order) order matching per swap tx.

Todo:
- [x] check that counter order are sorted by token price;
- [x] draft contracts for multiple counter orders;

Continued in https://github.com/ergoplatform/ergo-contracts/milestone/1