### PR TITLE
adds `addSignWithDhtData` so user can sign a transaction w/ single dht tuple

### DIFF
--- a/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/DummyWalletImpl.scala
+++ b/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/DummyWalletImpl.scala
@@ -1,12 +1,12 @@
 package org.ergoplatform.playgroundenv.models
 
+import java.util
 import org.ergoplatform.appkit.{AppkitProvingInterpreter, Iso, Mnemonic}
 import org.ergoplatform.wallet.mnemonic.{Mnemonic => WMnemonic}
 import org.ergoplatform.wallet.secrets.ExtendedSecretKey
 import org.ergoplatform.{ErgoLikeTransaction, UnsignedErgoLikeTransaction}
-import sigmastate.basics.DiffieHellmanTupleProverInput
-import sigmastate.eval.CSigmaProp
-import org.ergoplatform.playgroundenv.utils.TransactionVerifier
+import scala.collection.JavaConverters._
+import sigmastate.basics.{DiffieHellmanTupleProverInput, ProveDHTuple}
 
 class DummyWalletImpl(
   blockchain: DummyBlockchainSimulationImpl,
@@ -22,14 +22,25 @@ class DummyWalletImpl(
   override val getAddress: Address = Address(masterKey.publicKey.key)
 
   override def sign(tx: UnsignedErgoLikeTransaction): ErgoLikeTransaction = {
+    val dhtInputs      = new util.ArrayList[DiffieHellmanTupleProverInput](0)
+
+    signWithDHTInputs(dhtInputs, tx)
+  }
+
+  override def signWithDHTData(proveDHTuple: ProveDHTuple, tx: UnsignedErgoLikeTransaction): ErgoLikeTransaction = {
+    val dhtInputs : util.List[DiffieHellmanTupleProverInput] = List(DiffieHellmanTupleProverInput(masterKey.key.w, proveDHTuple)).asJava
+
+    signWithDHTInputs(dhtInputs, tx)
+  }
+
+  private def signWithDHTInputs(dhtInputs: util.List[DiffieHellmanTupleProverInput], tx: UnsignedErgoLikeTransaction) : ErgoLikeTransaction = {
     println(s"......$name: Signing transaction ${tx.id}")
     import Iso._
-    val dlogs =
+    val dLogs =
       JListToIndexedSeq(identityIso[ExtendedSecretKey]).from(IndexedSeq(masterKey))
-    val dhtInputs      = new java.util.ArrayList[DiffieHellmanTupleProverInput](0)
     val boxesToSpend   = tx.inputs.map(i => blockchain.getUnspentBox(i.boxId)).toIndexedSeq
     val dataInputBoxes = tx.dataInputs.map(i => blockchain.getBox(i.boxId)).toIndexedSeq
-    val prover         = new AppkitProvingInterpreter(dlogs, dhtInputs, blockchain.parameters)
+    val prover         = new AppkitProvingInterpreter(dLogs, dhtInputs, blockchain.parameters)
     prover.sign(tx, boxesToSpend, dataInputBoxes, blockchain.stateContext).get
   }
 }

--- a/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/DummyWalletImpl.scala
+++ b/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/DummyWalletImpl.scala
@@ -19,12 +19,12 @@ class DummyWalletImpl(
     ExtendedSecretKey.deriveMasterKey(seed)
   }
 
-  private val dHTInputs : util.List[DiffieHellmanTupleProverInput] =
+  private val dHTInputs: util.List[DiffieHellmanTupleProverInput] =
     new util.ArrayList[DiffieHellmanTupleProverInput](0)
 
   override val getAddress: Address = Address(masterKey.publicKey.key)
 
-  override def withDHSecret(proveDHTuple: ProveDHTuple) : Wallet = {
+  override def withDHSecret(proveDHTuple: ProveDHTuple): Wallet = {
     dHTInputs.add(DiffieHellmanTupleProverInput(masterKey.key.w, proveDHTuple))
     this
   }

--- a/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/Wallet.scala
+++ b/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/Wallet.scala
@@ -5,11 +5,11 @@ import sigmastate.basics.ProveDHTuple
 
 trait Wallet {
 
+  def withDHSecret(proveDHTuple: ProveDHTuple): Wallet
+
   def name: String
 
   def getAddress: Address
 
   def sign(tx: UnsignedErgoLikeTransaction): ErgoLikeTransaction
-
-  def signWithDHTData(proveDHTuple: ProveDHTuple, tx: UnsignedErgoLikeTransaction): ErgoLikeTransaction
 }

--- a/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/Wallet.scala
+++ b/playground-env/src/main/scala/org/ergoplatform/playgroundenv/models/Wallet.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.playgroundenv.models
 
 import org.ergoplatform.{ErgoLikeTransaction, UnsignedErgoLikeTransaction}
+import sigmastate.basics.ProveDHTuple
 
 trait Wallet {
 
@@ -10,4 +11,5 @@ trait Wallet {
 
   def sign(tx: UnsignedErgoLikeTransaction): ErgoLikeTransaction
 
+  def signWithDHTData(proveDHTuple: ProveDHTuple, tx: UnsignedErgoLikeTransaction): ErgoLikeTransaction
 }


### PR DESCRIPTION
It's used like this: https://scastie.scala-lang.org/x6bwPi9eRDiqX4m1cEJsNg

It works locally. Ideally, there'd be an available test suite but I'm having trouble locating it. So, if someone could take a look at this PR and explain if there are other steps.

Thanks.